### PR TITLE
feat : 담소 게시글 조회, 상세 조회, 게시글 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,15 +26,17 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	//testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Swagger (SpringDoc) - 최신 버전
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/TalkController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/TalkController.java
@@ -1,0 +1,57 @@
+package org.kosa.congmouse.nyanggoon.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
+import org.kosa.congmouse.nyanggoon.dto.TalkListSummaryResponseDto;
+import org.kosa.congmouse.nyanggoon.service.TalkService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+//담소 컨트롤러 입니다.
+@RestController
+@RequestMapping("/talks")
+@RequiredArgsConstructor
+@Slf4j
+public class TalkController {
+    private final TalkService talkService;
+
+    //게시글들을 가져오는 컨트롤러 입니다.
+    @GetMapping
+    public ResponseEntity<List<TalkListSummaryResponseDto>> getAllTalkList(){
+        log.info("게시글들 조회 컨트롤러 작동 ok");
+        List<TalkListSummaryResponseDto> talks = talkService.findAllTalkList();
+        return ResponseEntity.ok(talks);
+    }
+
+
+    //게시글을 상세 확인하는 컨트롤러 입니다.
+    @GetMapping("/{id}")
+    public ResponseEntity<TalkDetailResponseDto> getTalkDetailById(@PathVariable Long id){
+        log.info("게시글 상세 조회 컨트롤러 작동 ok");
+        TalkDetailResponseDto postDetailResponseDto = talkService.findTalkDetail(id);
+        return ResponseEntity.ok(postDetailResponseDto);
+    }
+    //게시글을 작성하는 컨트롤러 입니다.
+
+    //게시글을 수정하는 컨트롤러 입니다.
+
+    //게시글을 삭제하는 컨트롤러 입니다.
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTalkById(@PathVariable Long id){
+        log.info("게시글 삭제 컨트롤러 작동 ok");
+        log.info("삭제할 게시글 id : {}", id);
+        try{
+            talkService.deleteTalk(id);
+            return ResponseEntity.noContent().build();
+        }
+        catch(Exception e){
+        return  ResponseEntity.notFound().build();
+        }
+
+
+    }
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkDetailResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkDetailResponseDto.java
@@ -1,0 +1,33 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kosa.congmouse.nyanggoon.entity.Talk;
+
+import java.time.LocalDateTime;
+
+//담소 게시물을 상세 확인할 수 있게 하는 Dto 입니다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TalkDetailResponseDto {
+
+    private Long talkId;
+    private String title;
+    private String content;
+    private String authorName;
+    private LocalDateTime createdAt;
+
+    public static TalkDetailResponseDto from(Talk talk){
+        return TalkDetailResponseDto.builder()
+                .talkId(talk.getId())
+                .title(talk.getTitle())
+                .content(talk.getContent())
+                .authorName(talk.getMember().getNickname())
+                .createdAt(talk.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkListSummaryResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkListSummaryResponseDto.java
@@ -1,0 +1,33 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kosa.congmouse.nyanggoon.entity.Talk;
+
+import java.time.LocalDateTime;
+
+//담소 게시글 목록을 불러오는 Dto 입니다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TalkListSummaryResponseDto {
+    private Long talkId;
+    private String title;
+    private String content;
+    private String authorName;
+    private LocalDateTime createdAt;
+
+    public static TalkListSummaryResponseDto from(Talk talk){
+        return TalkListSummaryResponseDto.builder()
+                .talkId(talk.getId())
+                .title(talk.getTitle())
+                .content(talk.getContent())
+                .authorName(talk.getMember().getNickname())
+                .createdAt(talk.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/entity/Talk.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/entity/Talk.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @ToString
-
+//담소 엔티티 입니다.
 public class Talk {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,5 +37,10 @@ public class Talk {
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
+    
+    //연관 관계 메소드(단방향)
+    public void assignAuthor(Member member){ this.member = member; }
+
+
 }
-// 담소 entity
+

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/TalkRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/TalkRepository.java
@@ -1,0 +1,24 @@
+    package org.kosa.congmouse.nyanggoon.repository;
+
+    import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
+    import org.kosa.congmouse.nyanggoon.entity.Talk;
+    import org.springframework.data.jpa.repository.JpaRepository;
+    import org.springframework.data.jpa.repository.Query;
+    import org.springframework.data.repository.query.Param;
+    import org.springframework.stereotype.Repository;
+
+    import java.util.List;
+
+    @Repository
+    public interface TalkRepository extends JpaRepository<Talk, Long> {
+
+        //쿼리문은 엔티티 클래스명으로 작성해야 한다.
+        @Query("SELECT t FROM Talk t JOIN FETCH t.member")
+        List<Talk> findAllWithMember();
+
+        @Query("SELECT t FROM Talk t JOIN FETCH t.member WHERE t.id = :id")
+        TalkDetailResponseDto findTalkDetail(@Param("id") Long id);
+
+        //findById(Long id) : 자동 지원
+        // deleteById(Long id) : 자동 지원
+    }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/service/TalkService.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/service/TalkService.java
@@ -1,0 +1,52 @@
+package org.kosa.congmouse.nyanggoon.service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
+import org.kosa.congmouse.nyanggoon.dto.TalkListSummaryResponseDto;
+import org.kosa.congmouse.nyanggoon.entity.Talk;
+import org.kosa.congmouse.nyanggoon.repository.TalkRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+//담소 게시글의 Service 입니다.
+@Service
+@Transactional(readOnly= true)
+@RequiredArgsConstructor
+@Slf4j
+public class TalkService {
+
+    private final TalkRepository talkRepository;
+
+    //해당하는 담소 게시글을 찾는 메소드 입니다.
+    public Talk findTalkById(Long id){
+        return talkRepository.findById(id).orElseThrow(()-> new IllegalArgumentException("담소 id"+id+"에 해당하는 게시글을 찾을 수 없습니다."));
+    }
+
+    //모든 담소 게시글을 불러오는 메소드 입니다.
+    public List<TalkListSummaryResponseDto> findAllTalkList() {
+        log.info("담소 게시물을 전부 출력합니다.");
+        List<Talk> talkList = talkRepository.findAllWithMember();
+        return talkList.stream().map(TalkListSummaryResponseDto::from).collect(Collectors.toUnmodifiableList());
+    }
+
+    //담소 게시글의 상세를 조회하는 메소드 입니다.
+    public TalkDetailResponseDto findTalkDetail(Long id) {
+        log.info("해당 담소 게시물의 내용을 확인합니다. {}", id);
+        TalkDetailResponseDto talk = talkRepository.findTalkDetail(id);
+        return talk;
+    }
+
+    //담소 게시글을 삭제하는 메소드 입니다.
+    @Transactional
+    public void deleteTalk(Long id){
+        log.info("해당하는 담소 게시물을 삭제합니다. {}", id);
+        findTalkById(id);
+        //자동 지원되는 메소드를 사용한다.
+        talkRepository.deleteById(id);
+    }
+
+
+}


### PR DESCRIPTION
# 📑 PR 요약

<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
담소 게시글 조회, 상세 조회, 게시글 삭제 구현

## 🔗 관련 이슈


## ☑ 작업 내용

<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->

- 담소 게시글 조회
- 담소 게시글 상세 조회
- 담소 게시글 삭제
- build.gradle 수정 (security 주석 처리)

## 단위 테스트 결과

## ✅ 기타 사항
- 테스트를 위해 build.gradle 파일의 security를 주석 처리 했습니다. 이후 Spring Security를 구현한 후 주석을 풀면 됩니다.
