### PR TITLE
feat : 담소 상세에서 댓글과 대댓글을 조회할 수 있도록 구현

### DIFF
--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/TalkController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/TalkController.java
@@ -2,6 +2,7 @@ package org.kosa.congmouse.nyanggoon.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.ApiResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.TalkListSummaryResponseDto;
 import org.kosa.congmouse.nyanggoon.service.TalkService;
@@ -16,24 +17,27 @@ import java.util.List;
 @RequestMapping("/talks")
 @RequiredArgsConstructor
 @Slf4j
+//임시 설정 입니다. (추후 삭제)
+@CrossOrigin(origins = "http://localhost:5173")
 public class TalkController {
     private final TalkService talkService;
 
     //게시글들을 가져오는 컨트롤러 입니다.
     @GetMapping
-    public ResponseEntity<List<TalkListSummaryResponseDto>> getAllTalkList(){
+    public ResponseEntity<?> getAllTalkList(){
         log.info("게시글들 조회 컨트롤러 작동 ok");
         List<TalkListSummaryResponseDto> talks = talkService.findAllTalkList();
-        return ResponseEntity.ok(talks);
+        return ResponseEntity.ok(ApiResponseDto.success(talks, "게시물 목록 조회 성공"));
     }
 
 
     //게시글을 상세 확인하는 컨트롤러 입니다.
+    //댓글도 함께 가져옵니다.
     @GetMapping("/{id}")
-    public ResponseEntity<TalkDetailResponseDto> getTalkDetailById(@PathVariable Long id){
+    public ResponseEntity<?> getTalkDetailById(@PathVariable Long id){
         log.info("게시글 상세 조회 컨트롤러 작동 ok");
         TalkDetailResponseDto postDetailResponseDto = talkService.findTalkDetail(id);
-        return ResponseEntity.ok(postDetailResponseDto);
+        return ResponseEntity.ok(ApiResponseDto.success(postDetailResponseDto, "담소 게시글 조회 성공"));
     }
     //게시글을 작성하는 컨트롤러 입니다.
 
@@ -51,6 +55,12 @@ public class TalkController {
         catch(Exception e){
         return  ResponseEntity.notFound().build();
         }
+
+        //댓글을 작성하는 컨트롤러 입니다.
+
+        //댓글을 수정하는 컨트롤러 입니다.
+
+        //댓글을 삭제하는 컨트롤러 입니다.
 
 
     }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/ApiResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/ApiResponseDto.java
@@ -1,0 +1,37 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+/**
+ ApiResponseDto 입니다.
+ */
+@Getter
+@Builder
+public class ApiResponseDto<T> {
+    private final boolean success;
+    private final String message;
+    private final T data;
+    private final String code;
+    private final LocalDateTime timestamp;
+
+    public static <T> ApiResponseDto<T> success(T data, String message) {
+        return ApiResponseDto.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> error(String code, String message) {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .code(code)
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkCommentResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkCommentResponseDto.java
@@ -1,0 +1,40 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kosa.congmouse.nyanggoon.entity.TalkComment;
+
+import java.time.LocalDateTime;
+
+//담소 댓글을 가져오는 Dto 입니다.
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TalkCommentResponseDto {
+
+    private Long talkCommentId;
+    private String content;
+    private LocalDateTime createdAt;
+    private Long memberId;
+    private String nickname;
+    private Long talkId;
+    private Long talkparentCommentId;
+
+    public static TalkCommentResponseDto from(TalkComment talkComment){
+        return TalkCommentResponseDto.builder()
+                .talkCommentId(talkComment.getId())
+                .content(talkComment.getContent())
+                .createdAt(talkComment.getCreatedAt())
+                .memberId(talkComment.getMember().getId())
+                .nickname(talkComment.getMember().getNickname())
+                .talkId(talkComment.getTalk().getId())
+                //null 여부 체크
+                .talkparentCommentId(talkComment.getParentComment() != null ? talkComment.getParentComment().getId() : null)
+                .build();
+
+    }
+
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkDetailResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkDetailResponseDto.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import org.kosa.congmouse.nyanggoon.entity.Talk;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 //담소 게시물을 상세 확인할 수 있게 하는 Dto 입니다.
 @Getter
@@ -18,16 +20,21 @@ public class TalkDetailResponseDto {
     private Long talkId;
     private String title;
     private String content;
-    private String authorName;
+    private Long memberId;
+    private String nickname;
     private LocalDateTime createdAt;
+    // 댓글 리스트 추가
+    private List<TalkCommentResponseDto> comments;
 
-    public static TalkDetailResponseDto from(Talk talk){
+    public static TalkDetailResponseDto from(Talk talk , List<TalkCommentResponseDto> comments){
         return TalkDetailResponseDto.builder()
                 .talkId(talk.getId())
                 .title(talk.getTitle())
                 .content(talk.getContent())
-                .authorName(talk.getMember().getNickname())
+                .memberId(talk.getMember().getId())
+                .nickname(talk.getMember().getNickname())
                 .createdAt(talk.getCreatedAt())
+                .comments(comments)
                 .build();
     }
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkListSummaryResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/TalkListSummaryResponseDto.java
@@ -17,7 +17,8 @@ public class TalkListSummaryResponseDto {
     private Long talkId;
     private String title;
     private String content;
-    private String authorName;
+    private Long memberId;
+    private String nickname;
     private LocalDateTime createdAt;
 
     public static TalkListSummaryResponseDto from(Talk talk){
@@ -25,7 +26,8 @@ public class TalkListSummaryResponseDto {
                 .talkId(talk.getId())
                 .title(talk.getTitle())
                 .content(talk.getContent())
-                .authorName(talk.getMember().getNickname())
+                .memberId(talk.getMember().getId())
+                .nickname(talk.getMember().getNickname())
                 .createdAt(talk.getCreatedAt())
                 .build();
     }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/TalkRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/TalkRepository.java
@@ -1,7 +1,9 @@
     package org.kosa.congmouse.nyanggoon.repository;
 
+    import org.kosa.congmouse.nyanggoon.dto.TalkCommentResponseDto;
     import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
     import org.kosa.congmouse.nyanggoon.entity.Talk;
+    import org.kosa.congmouse.nyanggoon.entity.TalkComment;
     import org.springframework.data.jpa.repository.JpaRepository;
     import org.springframework.data.jpa.repository.Query;
     import org.springframework.data.repository.query.Param;
@@ -18,6 +20,13 @@
 
         @Query("SELECT t FROM Talk t JOIN FETCH t.member WHERE t.id = :id")
         TalkDetailResponseDto findTalkDetail(@Param("id") Long id);
+
+        @Query("SELECT c FROM TalkComment c " +
+                "JOIN FETCH c.member m " +
+                "JOIN FETCH c.talk t " +
+                "LEFT JOIN FETCH c.parentComment p " +
+                "WHERE t.id = :talkId")
+        List<TalkComment> findTalkComment(@Param("talkId") Long talkId);
 
         //findById(Long id) : 자동 지원
         // deleteById(Long id) : 자동 지원

--- a/src/main/java/org/kosa/congmouse/nyanggoon/service/TalkService.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/service/TalkService.java
@@ -1,9 +1,11 @@
 package org.kosa.congmouse.nyanggoon.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.TalkCommentResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.TalkDetailResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.TalkListSummaryResponseDto;
 import org.kosa.congmouse.nyanggoon.entity.Talk;
+import org.kosa.congmouse.nyanggoon.entity.TalkComment;
 import org.kosa.congmouse.nyanggoon.repository.TalkRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,10 +35,20 @@ public class TalkService {
     }
 
     //담소 게시글의 상세를 조회하는 메소드 입니다.
+    //댓글도 함께 가져옵니다.
     public TalkDetailResponseDto findTalkDetail(Long id) {
         log.info("해당 담소 게시물의 내용을 확인합니다. {}", id);
-        TalkDetailResponseDto talk = talkRepository.findTalkDetail(id);
-        return talk;
+        // 게시글 엔티티 가져오기
+        Talk talk = talkRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("게시글이 존재하지 않습니다."));
+        //해당 게시글의 댓글들을 가져옵니다.
+        List<TalkComment> talkComment = talkRepository.findTalkComment(id);
+        // DTO로 변환합니다.
+        List<TalkCommentResponseDto> talkCommentDtos = talkComment.stream()
+                .map(TalkCommentResponseDto::from)
+                .toList();
+
+        return TalkDetailResponseDto.from(talk, talkCommentDtos);
     }
 
     //담소 게시글을 삭제하는 메소드 입니다.


### PR DESCRIPTION
# 📑 PR 요약

<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
담소 상세에서 댓글과 대댓글을 조회할 수 있도록 구현
## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
#25 

## ☑ 작업 내용

<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->

- 담소 상세에서 댓글과 대댓글을 조회할 수 있도록 구현
- ApiResponseDto 추가

## 단위 테스트 결과

## ✅ 기타 사항
