### PR TITLE
feat : 국가유산청 API 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -433,3 +433,4 @@ gradle-app.setting
 /src/main/resources/application.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/java,react,windows,macos,maven,gradle,intellij,visualstudiocode,git,node
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // Swagger (SpringDoc) - 최신 버전
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // XML parser
+    implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/GoogleMapController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/GoogleMapController.java
@@ -2,11 +2,10 @@ package org.kosa.congmouse.nyanggoon.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.util.JSONPObject;
 import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.ApiResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,17 +16,18 @@ import java.math.BigDecimal;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/badge")
+@RequestMapping("/api/googlemap")
 @Slf4j
-public class BadgeController {
+public class GoogleMapController {
 
     @Value("${spring.google.map.key}")
     private String googleMapKey;
 
     @GetMapping("/coordinate")
     public ResponseEntity<?> getMapCoordinate(@RequestParam BigDecimal lat, @RequestParam BigDecimal lng){
-        String url = String.format("https://maps.googleapis.com/maps/api/geocode/json?latlng=%f,%f&key=%s&language=ko", lat, lng, googleMapKey
+        String url = String.format("https://maps.googleapis.com/maps/api/geocode/json?latlng=%s,%s&key=%s&language=ko", lat, lng, googleMapKey
         );
+
         RestTemplate restTemplate = new RestTemplate();
         String response = restTemplate.getForObject(url, String.class);
 
@@ -39,10 +39,9 @@ public class BadgeController {
             if (root.has("results") && root.get("results").isArray() && root.get("results").size() > 0) {
                 address = root.get("results").get(0).get("formatted_address").asText();
             }
-
             return ResponseEntity.ok(Map.of("address", address));
         }catch (Exception e) {
-            return ResponseEntity.internalServerError().body(Map.of("address", "서버 오류 발생"));
+            return ResponseEntity.internalServerError().body("서버 오류 발생");
         }
     }
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/HeritageController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/HeritageController.java
@@ -1,0 +1,39 @@
+package org.kosa.congmouse.nyanggoon.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.ApiResponseDto;
+import org.kosa.congmouse.nyanggoon.dto.HeritageListResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/heritages")
+@Slf4j
+public class HeritageController {
+    @GetMapping("/markers")
+    public ResponseEntity<?> getHeritageList(){
+        String url = "https://www.khs.go.kr/cha/SearchKindOpenapiList.do?pageUnit=1000&ccbaCncl=N&ccbaKdcd=11&ccbaCtcd=11";
+        RestTemplate restTemplate = new RestTemplate();
+        try{
+            String xmlResponse = restTemplate.getForObject(url, String.class);
+            XmlMapper xmlMapper = new XmlMapper();
+            Map<String, Object> root = xmlMapper.readValue(xmlResponse, Map.class);
+            List<Map<String, Object>> itemList = (List<Map<String, Object>>) root.get("item");
+            String itemListToJson = xmlMapper.writeValueAsString(itemList);
+            List<HeritageListResponseDto> heritageListResponseDtos =
+                    xmlMapper.readValue(itemListToJson, new TypeReference<List<HeritageListResponseDto>>() {});
+            return ResponseEntity.ok(ApiResponseDto.success(heritageListResponseDtos, "유적 조회 성공"));
+        }catch(Exception e){
+            return ResponseEntity.internalServerError().body(ApiResponseDto.error("500", "서버 오류 발생"));
+        }
+    }
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/HeritageListResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/HeritageListResponseDto.java
@@ -1,0 +1,49 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kosa.congmouse.nyanggoon.entity.HeritageEncyclopedia;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonDeserialize(builder = HeritageListResponseDto.HeritageListResponseDtoBuilder.class)
+public class HeritageListResponseDto {
+//    @JacksonXmlProperty(localName="no")
+//    private Long id;
+    @JacksonXmlProperty(localName="ccbaKdcd")
+    private int subjectCode;
+    @JacksonXmlProperty(localName="ccbaMnm1")
+    private String name;
+    @JacksonXmlProperty(localName="ccbaLcad")
+    private String address;
+    @JacksonXmlProperty(localName="latitude")
+    private BigDecimal latitude;
+    @JacksonXmlProperty(localName="longitude")
+    private BigDecimal longitude;
+
+    public static HeritageListResponseDto from(HeritageEncyclopedia heritageEncyclopedia){
+        return HeritageListResponseDto.builder()
+//                .id(heritageEncyclopedia.getId())
+                .subjectCode(heritageEncyclopedia.getSubjectCode())
+                .name(heritageEncyclopedia.getName())
+                .address(heritageEncyclopedia.getAddress())
+                .latitude(heritageEncyclopedia.getLatitude())
+                .longitude(heritageEncyclopedia.getLongitude()).build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    // Builder 클래스를 명시해줘야 @JsonDeserialize가 제대로 동작함
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class HeritageListResponseDtoBuilder {}
+}


### PR DESCRIPTION
# 📑 PR 요약
feat : 국가유산청 API 처리

## 🔗 관련 이슈

## ☑ 작업 내용
국가유산청 API 처리
- 작업 1 : Controller, Dto 제작
- 작업 2 : 국가 유산청 api 받아서 xml 파싱 -> json 변경해 프론트로 내려줌

## 단위 테스트 결과
- 브라우저, log 확인

## ✅ 기타 사항
