### PR TITLE
feat : 문화재 인증 페이지 모달 등 기능 추가

### DIFF
--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/BadgeController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/BadgeController.java
@@ -42,4 +42,13 @@ public class BadgeController {
         List<Long> acquiredBadgeIds  = badgeService.findAcquiredBadgesList(memberId);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.success(acquiredBadgeIds, "획득한 증표 id 목록 조회 성공"));
     }
+
+    // 지도에 표시할 이미 획득한 증표(유저에 따라)
+    @GetMapping("/badgebox")
+    public ResponseEntity<?> getCollectedBadgesByMemberId(@AuthenticationPrincipal CustomMemberDetails member){
+        log.info("대체 왜?");
+        Long memberId = (member != null) ? member.getMemberId() : null;
+        List<HunterBadgesAcquisitionResponseDto> HunterBadgesAcquisitionResponseDto  = badgeService.findCollectedBadgesList(memberId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.success(HunterBadgesAcquisitionResponseDto, "획득한 증표 id 목록 조회 성공"));
+    }
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/HunterBadgeAcquireResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/HunterBadgeAcquireResponseDto.java
@@ -13,14 +13,14 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class HunterBadgeAcquireResponseDto {
-    private Long badgeId;
+    private Long hunterBadgeAcquisitionId;
     private LocalDateTime acquisitionDate;
     private Member member;
     private HunterBadge hunterBadge;
 
     public static HunterBadgeAcquireResponseDto from(HunterBadgeAcquisition hunterBadgeAcquisition){
         return HunterBadgeAcquireResponseDto.builder()
-                .badgeId(hunterBadgeAcquisition.getId())
+                .hunterBadgeAcquisitionId(hunterBadgeAcquisition.getId())
                 .acquisitionDate(hunterBadgeAcquisition.getAcquisitionDate())
                 .member(hunterBadgeAcquisition.getMember())
                 .hunterBadge(hunterBadgeAcquisition.getHunterBadge())

--- a/src/main/java/org/kosa/congmouse/nyanggoon/dto/HunterBadgesAcquisitionResponseDto.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/dto/HunterBadgesAcquisitionResponseDto.java
@@ -1,0 +1,33 @@
+package org.kosa.congmouse.nyanggoon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kosa.congmouse.nyanggoon.entity.HunterBadge;
+import org.kosa.congmouse.nyanggoon.entity.HunterBadgeAcquisition;
+import org.kosa.congmouse.nyanggoon.entity.Member;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HunterBadgesAcquisitionResponseDto {
+    private Long hunterBadgeAcquisitionId;
+    private LocalDateTime acquisitionDate;
+    private Long hunterBadgeId;
+    private String badgeName;
+    private String badgeImg;
+
+    public static HunterBadgesAcquisitionResponseDto from(HunterBadgeAcquisition hunterBadgeAcquisition){
+        return HunterBadgesAcquisitionResponseDto.builder()
+                .hunterBadgeAcquisitionId(hunterBadgeAcquisition.getId())
+                .acquisitionDate(hunterBadgeAcquisition.getAcquisitionDate())
+                .hunterBadgeId(hunterBadgeAcquisition.getHunterBadge().getId())
+                .badgeName(hunterBadgeAcquisition.getHunterBadge().getName())
+                .badgeImg(hunterBadgeAcquisition.getHunterBadge().getImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/HunterBadgeAcquisitionRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/HunterBadgeAcquisitionRepository.java
@@ -1,5 +1,6 @@
 package org.kosa.congmouse.nyanggoon.repository;
 
+import org.kosa.congmouse.nyanggoon.dto.HunterBadgesAcquisitionResponseDto;
 import org.kosa.congmouse.nyanggoon.entity.HunterBadgeAcquisition;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,7 @@ public interface HunterBadgeAcquisitionRepository extends JpaRepository<HunterBa
 
     @Query("SELECT hba.hunterBadge.id FROM HunterBadgeAcquisition hba WHERE hba.member.id = :memberId")
     List<Long> findBadgeIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT hba FROM HunterBadgeAcquisition hba WHERE hba.member.id = :memberId")
+    List<HunterBadgeAcquisition> findBadgeListByMemberId(Long memberId);
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/security/config/SecurityConfig.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/security/config/SecurityConfig.java
@@ -76,14 +76,16 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/talks/detail/{id}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/photobox").permitAll()
                 .requestMatchers(HttpMethod.GET, "/photobox/{id}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/heritages/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/badges/**").permitAll()
                 .requestMatchers("/uploads/**").permitAll()
                 // 관리자 기능
                 .requestMatchers("/admin/**").hasRole("ADMIN")
 
                 // 참고 /api/product/ , /api/products/** 경로에 대한 접근을 모두 허용
-                .requestMatchers("/swagger-ui").permitAll()
+                .requestMatchers("/swagger-ui/**").permitAll()
                 .requestMatchers("/api-docs").permitAll()
-                .requestMatchers("/heritages/*").permitAll()
+                .requestMatchers("/heritages/**").permitAll()
 
                 // 챗봇 API는 인증 필요
                 .requestMatchers("/api/chat/**").authenticated()

--- a/src/main/java/org/kosa/congmouse/nyanggoon/service/BadgeService.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/service/BadgeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kosa.congmouse.nyanggoon.dto.HunterBadgeAcquireResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.HunterBadgeMarkerResponseDto;
+import org.kosa.congmouse.nyanggoon.dto.HunterBadgesAcquisitionResponseDto;
 import org.kosa.congmouse.nyanggoon.entity.HunterBadge;
 import org.kosa.congmouse.nyanggoon.entity.HunterBadgeAcquisition;
 import org.kosa.congmouse.nyanggoon.entity.Member;
@@ -38,7 +39,6 @@ public class BadgeService {
 
     /**
      * 획득한 증표를 저장하는 메서드
-     *
      * @param badgeId
      * @param memberId
      * @return
@@ -58,12 +58,12 @@ public class BadgeService {
         HunterBadge hunterBadge = hunterBadgeRepository.findById(badgeId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 증표입니다."));
 
         // 3. 획득한 증표를 증표함에 save
-        HunterBadgeAcquisition newAquiredBadge = HunterBadgeAcquisition.builder()
+        HunterBadgeAcquisition newAcquiredBadge = HunterBadgeAcquisition.builder()
                                                 .member(member)
                                                 .hunterBadge(hunterBadge)
                                                 .build();
-        HunterBadgeAcquisition savedAquiredBadge = hunterBadgeAcquisitionRepository.save(newAquiredBadge);
-        return HunterBadgeAcquireResponseDto.from(savedAquiredBadge);
+        HunterBadgeAcquisition savedAcquiredBadge = hunterBadgeAcquisitionRepository.save(newAcquiredBadge);
+        return HunterBadgeAcquireResponseDto.from(savedAcquiredBadge);
     }
 
     /**
@@ -73,5 +73,14 @@ public class BadgeService {
      */
     public List<Long> findAcquiredBadgesList(Long memberId) {
         return hunterBadgeAcquisitionRepository.findBadgeIdsByMemberId(memberId);
+    }
+
+    /**
+     * 획득한 증표(증표함에 표시)
+     * @param memberId
+     * @return
+     */
+    public List<HunterBadgesAcquisitionResponseDto> findCollectedBadgesList(Long memberId) {
+        return hunterBadgeAcquisitionRepository.findBadgeListByMemberId(memberId).stream().map(HunterBadgesAcquisitionResponseDto::from).collect(Collectors.toUnmodifiableList());
     }
 }


### PR DESCRIPTION
# 📑 PR 요약
feat : 문화재 인증 페이지 모달 등 기능 추가

## 🔗 관련 이슈
#30 

## ☑ 작업 내용
1. 획득한 증표 색깔 바꾸기
2. 증표 획득 했을 때 모달 띄우기
3. 내가 획득할 수 있는 증표가 여러개인 경우 가까운 증표 순으로 인식

## 단위 테스트 결과

## ✅ 기타 사항
