### PR TITLE
feat : 메인 화면 탐방기 조회 구현

### DIFF
--- a/src/main/java/org/kosa/congmouse/nyanggoon/controller/HomeController.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/controller/HomeController.java
@@ -3,6 +3,7 @@ package org.kosa.congmouse.nyanggoon.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kosa.congmouse.nyanggoon.dto.ApiResponseDto;
+import org.kosa.congmouse.nyanggoon.dto.ExplorationDetailDto;
 import org.kosa.congmouse.nyanggoon.dto.HeritageEncyclopediaResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.PhotoBoxDetailResponseDto;
 import org.kosa.congmouse.nyanggoon.service.HomeService;
@@ -41,14 +42,15 @@ public class HomeController {
     @GetMapping("/photobox")
     public ResponseEntity<?> getPhotoBoxByBookmark(){
         PhotoBoxDetailResponseDto photoBoxDetailResponseDto = homeService.getPhotoBoxByBookmark();
-        return ResponseEntity.ok(ApiResponseDto.success(photoBoxDetailResponseDto, "사진함 조회 성공"));
+        return ResponseEntity.ok(ApiResponseDto.success(photoBoxDetailResponseDto, "메인 사진함 조회 성공"));
 
     }
 
     //메인에서 탐방기 게시글을 띄워줍니다.
     //북마크 수가 가장 높은 게시글 4개를 띄워줍니다.
     @GetMapping("/exploration")
-    public void getExplorationByBookmark(){
-
+    public ResponseEntity<?> getExplorationByBookmark(){
+        List<ExplorationDetailDto> explorationDetailDtoList = homeService.getExplorationByBookmark();
+        return ResponseEntity.ok(ApiResponseDto.success(explorationDetailDtoList, "메인 탐방기 정보 조회 성공"));
     }
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/ExplorationRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/ExplorationRepository.java
@@ -2,6 +2,7 @@ package org.kosa.congmouse.nyanggoon.repository;
 
 import org.kosa.congmouse.nyanggoon.dto.ExplorationDetailDto;
 import org.kosa.congmouse.nyanggoon.entity.Exploration;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -40,4 +41,12 @@ public interface ExplorationRepository extends JpaRepository<Exploration, Long> 
             "ORDER BY e.createdAt DESC"
     )
     List<ExplorationDetailDto> findAllWithBookmarkCountAndCommentCounts();
+
+
+    //북마크 순으로 탐방기를 가져오는 메소드 입니다.
+    @Query("SELECT e FROM Exploration e JOIN ExplorationBookmark eb ON e.id = eb.exploration.id GROUP BY e.id ORDER BY COUNT(eb.id) DESC ")
+    List<Exploration> findExplorationTop4ByBookmarkCount(Pageable pageable);
+
+    @Query("SELECT e FROM Exploration e ORDER BY e.createdAt DESC")
+    List<Exploration> findLatestExplorations(Pageable latestPageable);
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/HeritageEncyclopediaRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/HeritageEncyclopediaRepository.java
@@ -68,11 +68,10 @@ public interface HeritageEncyclopediaRepository extends JpaRepository<HeritageEn
 
     //북마크 수에 따라 상위 4개를 가져오는 메소드 입니다.
     @Query("SELECT h FROM HeritageEncyclopedia h JOIN EncyclopediaBookmark eb ON h.id = eb.heritageEncyclopedia.id GROUP BY h.id ORDER BY COUNT(eb.id) DESC ")
-    List<HeritageEncyclopedia> findTop4ByBookmarkCount(Pageable pageable);
+    List<HeritageEncyclopedia> findHeritageTop4ByBookmarkCount(Pageable pageable);
 
-//    //랜덤한 문화재를 가져오는 메소드 입니다.
-//
-//    List<HeritageEncyclopedia> findRandomHeritage(Pageable pageable);
-
+    //랜덤한 문화재를 가져오는 메소드 입니다.
+    @Query(value = "SELECT * FROM heritage_encyclopedias ORDER BY RAND()", nativeQuery = true)
+    List<HeritageEncyclopedia> findRandomHeritage(Pageable pageable);
 
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/service/HomeService.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/service/HomeService.java
@@ -2,8 +2,10 @@ package org.kosa.congmouse.nyanggoon.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.kosa.congmouse.nyanggoon.dto.ExplorationDetailDto;
 import org.kosa.congmouse.nyanggoon.dto.HeritageEncyclopediaResponseDto;
 import org.kosa.congmouse.nyanggoon.dto.PhotoBoxDetailResponseDto;
+import org.kosa.congmouse.nyanggoon.entity.Exploration;
 import org.kosa.congmouse.nyanggoon.entity.HeritageEncyclopedia;
 import org.kosa.congmouse.nyanggoon.entity.PhotoBox;
 import org.kosa.congmouse.nyanggoon.entity.PhotoBoxPicture;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly= true)
@@ -25,34 +28,38 @@ public class HomeService {
     private final PhotoBoxPictureRepository photoBoxPictureRepository;
     private final PhotoBoxTagRepository photoBoxTagRepository;
     private final PhotoBoxBookmarkRepository photoBoxBookmarkRepository;
+    private final ExplorationRepository explorationRepository;
 
     //문화재 도감 정보를 가져오는 메소드 입니다.
     //총 4개, 전체 북마크 순으로 가져옵니다. (비회원일 시)
     //총 4개, 회원이 북마크한 것과 유사한 문화재를 가져옵니다. (회원일 시)
     public List<HeritageEncyclopediaResponseDto> getEncyclopediaByBookmark(String username) {
-        log.info("도감 정보 4개를 가져옵니다.");
+        log.info("도감 정보를 북마크 순으로 가져옵니다. 4개를 가져옵니다.");
 
         Pageable pageable = PageRequest.of(0, 4);
-        List<HeritageEncyclopedia> heritageEncyclopedias = heritageEncyclopediaRepository.findTop4ByBookmarkCount(pageable);
+        List<HeritageEncyclopedia> heritageEncyclopedias = heritageEncyclopediaRepository.findHeritageTop4ByBookmarkCount(pageable);
 
         //북마크 수와 북마크 여부는 따로 세지 않습니다. (0, false로 나옴)
         List<HeritageEncyclopediaResponseDto> heritageEncyclopediaResult = heritageEncyclopedias.stream()
                 .map(heritage -> HeritageEncyclopediaResponseDto.from(heritage, 0, false))
-                .toList();
+                .collect(Collectors.toList());
 
 
-//        //만약 추출한 북마크 개수가 4개 이하라면
-//        //랜덤한 문화재를 넣습니다.
-//        if (heritageEncyclopediaResult.size() < 4) {
-//            int remaining = 4 - heritageEncyclopediaResult.size();
-//            List<HeritageEncyclopedia> heritageEncyclopediaRandom = heritageEncyclopediaRepository.findRandomHeritage(pageable);
-//
-//            List<HeritageEncyclopediaResponseDto> heritageEncyclopediaRandomResults = heritageEncyclopedias.stream()
-//                    .map(heritage -> HeritageEncyclopediaResponseDto.from(heritage, 0, false))
-//                    .toList();
-//
-//            heritageEncyclopediaResult.addAll(heritageEncyclopediaRandomResults);
-//        }
+        //만약 추출한 북마크 개수가 4개 이하라면
+        //랜덤한 문화재를 넣습니다.
+
+        if (heritageEncyclopediaResult.size() < 4) {
+            log.info("북마크 총 개수 4개 이하 - 랜덤한 문화재를 넣습니다.");
+            int remaining = 4 - heritageEncyclopediaResult.size();
+            Pageable randomPageable = PageRequest.of(0, remaining); // 남은 개수만큼만 랜덤으로 가져오기
+            List<HeritageEncyclopedia> heritageEncyclopediaRandom = heritageEncyclopediaRepository.findRandomHeritage(randomPageable);
+
+            List<HeritageEncyclopediaResponseDto> heritageEncyclopediaRandomResults = heritageEncyclopediaRandom.stream()
+                    .map(heritage -> HeritageEncyclopediaResponseDto.from(heritage, 0, false))
+                    .toList();
+
+            heritageEncyclopediaResult.addAll(heritageEncyclopediaRandomResults);
+        }
 
 
         return heritageEncyclopediaResult;
@@ -91,4 +98,31 @@ public class HomeService {
 
     //탐방기의 내용을 가져오는 메소드 입니다.
     //총 4개, 전체 북마크 순으로 가져옵니다.
+    //북마크가 없다면 최신 순으로 가져옵니다.
+    public List<ExplorationDetailDto> getExplorationByBookmark() {
+        log.info("탐방기를 북마크 순으로 가져옵니다. 4개를 가져옵니다.");
+
+        Pageable pageable = PageRequest.of(0, 4);
+        List<Exploration> explorations = explorationRepository.findExplorationTop4ByBookmarkCount(pageable);
+        List<ExplorationDetailDto> explorationResult = explorations.stream()
+                .map(ExplorationDetailDto::from)
+                .collect(Collectors.toList());
+
+        // 4개 미만일 경우 최신 탐방기로 채우기
+        if (explorationResult.size() < 4) {
+            log.info("탐방기 북마크 수가 4개 이하 - 최신 탐방기로 채웁니다.");
+            int remaining = 4 - explorationResult.size();
+
+            Pageable latestPageable = PageRequest.of(0, remaining);
+            List<Exploration> latestExplorations = explorationRepository.findLatestExplorations(latestPageable);
+
+            List<ExplorationDetailDto> latestResults = latestExplorations.stream()
+                    .map(ExplorationDetailDto::from)
+                    .collect(Collectors.toList());
+
+            explorationResult.addAll(latestResults);
+        }
+        return explorationResult;
+    }
+
 }


### PR DESCRIPTION
# 📑 PR 요약

<!-- 이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요. -->
 메인 화면 탐방기 조회 구현
## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용

<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->

-  메인 화면 탐방기 조회 구현

## 단위 테스트 결과

- 사진 첨부

## ✅ 기타 사항
- 도감 조회 시 전체 북마크 횟수 순으로 4개를 가져옵니다.
- 만약 북마크 데이터가 없다면 (또는 4개가 안된다면) 랜덤으로 4개의 도감을 가져옵니다.
- 탐방기 조회 시 전체 북마크 횟수 순으로 4개를 가져옵니다.
- 만약 북마크 데이터가 없다면 (또는 4개가 안된다면) 최신 순으로 게시글을 가져옵니다.
- 테스트 시 도감 데이터가 db에 존재해야 하며, 탐방기 게시글이 최소 하나는 있어야 게시글이 나타납니다. 사진함도 마찬가지입니다.
- 만약 db가 비어있다면 북마크된 게시글이 없다는 문구가 화면에 출력됩니다.
