### PR TITLE
feat : 프로필 사진 레퍼지토리 생성

### DIFF
--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/MemberRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/MemberRepository.java
@@ -1,7 +1,12 @@
 package org.kosa.congmouse.nyanggoon.repository;
 
 import org.kosa.congmouse.nyanggoon.entity.Member;
+import org.kosa.congmouse.nyanggoon.entity.MemberState;
+import org.kosa.congmouse.nyanggoon.entity.ProfilePicture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -14,4 +19,37 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    @Modifying
+    @Query("""
+        UPDATE Member m SET
+            m.email = COALESCE(:email, m.email),
+            m.nickname = COALESCE(:nickname, m.nickname),
+            m.phoneNumber = COALESCE(:phoneNumber, m.phoneNumber),
+            m.password = COALESCE(:password, m.password)
+        WHERE m.id = :id
+    """)
+    void updateMemberInfo(
+            @Param("id") Long memberId,
+            @Param("email") String email,
+            @Param("nickname") String nickname,
+            @Param("phoneNumber") String phoneNumber,
+            @Param("password") String password
+    );
+
+    @Modifying
+    @Query("""
+    UPDATE Member m SET
+        m.profilePicture = :profilePicture
+    WHERE m.id = :id 
+    """)
+    void updateProfilePicture(
+            @Param("id") Long memberId,
+            @Param("profilePicture") ProfilePicture profilePicture
+    );
+
+    // 관리자 제재 기능: 회원의 상태(MemberState)를 변경합니다.
+//    @Modifying
+//    @Query("UPDATE Member m SET m.memberstate = :state WHERE m.id = :id")
+//    void updateMemberState(@Param("id") Long memberId, @Param("state") MemberState state);
 }

--- a/src/main/java/org/kosa/congmouse/nyanggoon/repository/ProfilePictureRepository.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/repository/ProfilePictureRepository.java
@@ -1,0 +1,18 @@
+package org.kosa.congmouse.nyanggoon.repository;
+
+import org.kosa.congmouse.nyanggoon.entity.Member;
+import org.kosa.congmouse.nyanggoon.entity.ProfilePicture;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProfilePictureRepository extends JpaRepository<ProfilePicture, Long> {
+
+    // Member Entity를 기준으로 ProfilePicture를 찾는 쿼리
+    Optional<ProfilePicture> findByMember(Member member);
+
+    // Member Entity를 기준으로 ProfilePicture를 삭제하는 쿼리
+    void deleteByMember(Member member);
+}

--- a/src/main/java/org/kosa/congmouse/nyanggoon/service/MyPageService.java
+++ b/src/main/java/org/kosa/congmouse/nyanggoon/service/MyPageService.java
@@ -7,13 +7,14 @@ import org.kosa.congmouse.nyanggoon.dto.MemberUpdateRequestDto;
 import org.kosa.congmouse.nyanggoon.entity.Member;
 import org.kosa.congmouse.nyanggoon.entity.ProfilePicture;
 import org.kosa.congmouse.nyanggoon.repository.MemberRepository;
+import org.kosa.congmouse.nyanggoon.repository.ProfilePictureRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.lang.reflect.Field;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -22,54 +23,171 @@ import java.lang.reflect.Field;
 public class MyPageService {
 
     private final MemberRepository memberRepository;
+    private final ProfilePictureRepository profilePictureRepository;
     private final PasswordEncoder passwordEncoder;
 
+    /* =================== 내 정보 조회 =================== */
     public MemberResponseDto getProfileData(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."));
-
-        log.info("회원 기본 정보 조회 완료: userId={}", memberId);
+        log.info("회원 정보 조회 완료: ID={}", memberId);
         return MemberResponseDto.from(member);
     }
 
+    /* =================== 내 정보 수정 =================== */
     @Transactional
     public MemberResponseDto updateProfile(Long memberId, MemberUpdateRequestDto dto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."));
 
-        try {
-            if (dto.getEmail() != null && !dto.getEmail().isBlank()) {
-                setPrivateField(member, "email", dto.getEmail());
-            }
-            if (dto.getNickname() != null && !dto.getNickname().isBlank()) {
-                setPrivateField(member, "nickname", dto.getNickname());
-            }
-            if (dto.getPhoneNumber() != null && !dto.getPhoneNumber().isBlank()) {
-                setPrivateField(member, "phoneNumber", dto.getPhoneNumber());
-            }
-            if (dto.getPassword() != null && !dto.getPassword().isBlank()) {
-                setPrivateField(member, "password", passwordEncoder.encode(dto.getPassword()));
-            }
-            if (dto.getProfileImage() != null && !dto.getProfileImage().isBlank()) {
-                ProfilePicture profilePicture = new ProfilePicture();
-                setPrivateField(member, "profilePicture", profilePicture);
-            }
+        // 이메일, 닉네임, 전화번호, 비밀번호 업데이트
+        String email = dto.getEmail() != null ? dto.getEmail() : member.getEmail();
+        String nickname = dto.getNickname() != null ? dto.getNickname() : member.getNickname();
+        String phone = dto.getPhoneNumber() != null ? dto.getPhoneNumber() : member.getPhoneNumber();
 
-            log.info("회원 정보 수정 완료: userId={}", memberId);
-            return MemberResponseDto.from(member);
+        String password = dto.getPassword() != null && !dto.getPassword().isBlank()
+                ? passwordEncoder.encode(dto.getPassword())
+                : member.getPassword();
 
-        } catch (Exception e) {
-            log.error("회원 정보 수정 중 오류 발생: {}", e.getMessage());
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "회원 정보 수정 중 오류 발생");
+        memberRepository.updateMemberInfo(memberId, email, nickname, phone, password);
+
+        // 프로필 이미지 처리
+        if (dto.getProfileImage() != null) {
+            if (!dto.getProfileImage().isBlank()) {
+                // 기존 이미지 삭제 후 새로 저장
+                profilePictureRepository.deleteByMember(member);
+
+                String path = dto.getProfileImage();
+                String originalName = path.substring(path.lastIndexOf('/') + 1);
+
+                ProfilePicture picture = ProfilePicture.builder()
+                        .path(path)
+                        .originalName(originalName)
+                        .savedName(UUID.randomUUID() + "_" + originalName)
+                        .size(0L)
+                        .fileExtension(getFileExtension(originalName))
+                        .build();
+
+                picture.profileOwner(member);
+                profilePictureRepository.save(picture);
+                log.info("프로필 이미지 수정 완료: {}", path);
+            } else {
+                // 빈 문자열일 경우 이미지 삭제 요청
+                profilePictureRepository.deleteByMember(member);
+                log.info("프로필 이미지 삭제 완료: memberId={}", memberId);
+            }
         }
+
+        Member updated = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "수정된 회원 정보를 찾을 수 없습니다."));
+        return MemberResponseDto.from(updated);
     }
 
-    // 리플렉션을 이용해 private 필드 값 수정하는 헬퍼 메서드
-    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
-        Field field = target.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true); // private 접근 허용
-        field.set(target, value);
+    /* =================== 회원 탈퇴 =================== */
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "탈퇴할 회원을 찾을 수 없습니다."));
+        memberRepository.delete(member);
+        log.info("회원 탈퇴 완료: ID={}", memberId);
     }
+
+//    /* =================== 관리자 제재 (상태 변경) =================== */
+//    @Transactional
+//    public void sanctionMember(Long memberId) {
+//        Member member = memberRepository.findById(memberId)
+//                .orElseThrow(() -> new ResponseStatusException(
+//                        HttpStatus.NOT_FOUND, "제재할 회원을 찾을 수 없습니다."));
+//
+//        // 현재 상태가 DISABLE인지 먼저 체크
+//        if (member.getMemberstate() == MemberState.DISABLE) {
+//            log.warn("이미 제재 상태인 회원: {}", memberId);
+//            return;
+//        }
+//
+//        // 상태 변경
+//        memberRepository.updateMemberState(memberId, MemberState.DISABLE);
+//        log.info("회원 제재 완료: ID={}", memberId);
+//    }
+//
+    /* =================== Helper =================== */
+    private String getFileExtension(String originalName) {
+        if (originalName != null && originalName.contains(".")) {
+            String ext = originalName.substring(originalName.lastIndexOf(".") + 1);
+            return ext.length() > 10 ? ext.substring(0, 10) : ext.toLowerCase();
+        }
+        return "";
+    }
+
+    /* =================== 탐방기 / 게시글 =================== */
+
+    //    // 내 게시글
+    //    public List<ExplorationDetailDto> getMyPosts(Long memberId) {
+    //        log.info("내 게시글 조회: userId={}", memberId);
+    //        return explorationRepository.findAllByMemberIdWithCounts(memberId);
+    //    }
+    //
+    //    // 내가 북마크한 게시글
+    //    public List<ExplorationDetailDto> getMyBookmarks(Long memberId) {
+    //        log.info("내 북마크 게시글 조회: userId={}", memberId);
+    //        return explorationBookmarkRepository.findExplorationBookmarksByMember(memberId).stream()
+    //                .map(ExplorationDetailDto::from)
+    //                .toList();
+    //    }
+    //
+    //    // 내가 작성한 댓글 (Talk)
+    //    public List<TalkDetailResponseDto> getMyComments(Long memberId) {
+    //        log.info("내 댓글 조회: userId={}", memberId);
+    //        return talkCommentRepository.findTalkCommentsByMember(memberId).stream()
+    //                .map(TalkDetailResponseDto::from)
+    //                .toList();
+    //    }
+    //
+    //    // 내가 북마크한 담소
+    //    public List<TalkDetailResponseDto> getMyBookmarkedTalks(Long memberId) {
+    //        log.info("내 담소 북마크 조회: userId={}", memberId);
+    //        return talkBookmarkRepository.findTalkBookmarksByMember(memberId).stream()
+    //                .map(TalkDetailResponseDto::from)
+    //                .toList();
+    //    }
+    //
+    //    /* =================== 사진 =================== */
+    //
+    //    // 내가 업로드한 사진
+    //    public List<PhotoBoxDetailResponseDto> getMyPhotos(Long memberId) {
+    //        log.info("내 사진 조회: userId={}", memberId);
+    //        return photoBoxRepository.findPhotoBoxesByMember(memberId).stream()
+    //                .map(PhotoBoxDetailResponseDto::from)
+    //                .toList();
+    //    }
+    //
+    //    // 내가 북마크한 사진
+    //    public List<PhotoBoxDetailResponseDto> getMyBookmarkedPhotos(Long memberId) {
+    //        log.info("내 북마크 사진 조회: userId={}", memberId);
+    //        return photoBoxRepository.findBookmarkedPhotoBoxesByMember(memberId).stream()
+    //                .map(PhotoBoxDetailResponseDto::from)
+    //                .toList();
+    //    }
+    //
+    //    // 내가 댓글 단 사진
+    //    public List<PhotoBoxDetailResponseDto> getMyCommentedPhotos(Long memberId) {
+    //        log.info("내 댓글 단 사진 조회: userId={}", memberId);
+    //        return photoBoxRepository.findCommentedPhotoBoxesByMember(memberId).stream()
+    //                .map(PhotoBoxDetailResponseDto::from)
+    //                .toList();
+    //    }
+    //
+    //    /* =================== 도감 =================== */
+    //
+    //    // 내가 북마크한 도감
+    //    public List<EncyclopediaBookmarkDto> getMyBookmarkedEncyclopedia(Long memberId) {
+    //        log.info("내 도감 북마크 조회: userId={}", memberId);
+    //        return heritageEncyclopediaRepository.findBookmarksByMember(memberId).stream()
+    //                .map(EncyclopediaBookmarkDto::from)
+    //                .toList();
+    //    }
 }


### PR DESCRIPTION
fix : 프로필 사진 저장 및 서버 경로 수정, 유저 정보 호출 실패 수정

# 📑 PR 요약

1. 프로필 사진 레퍼지토리 추가
2. 프로필 사진 저장 경로 설정, 저장 확인
3. 서버 경로 잘못되어 수정
4. 유저 정보 호출시 실패 한것 수정해 불러오기 가능

## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용

<!-- 이 PR에서 어떤 작업이 있었는지 작성해주세요. -->

- 작업 1
- 작업 2

## 단위 테스트 결과

- 사진 첨부

## ✅ 기타 사항
